### PR TITLE
Eliminate redundant error logging throughout codebase

### DIFF
--- a/cmd/cli-stat-creator/main.go
+++ b/cmd/cli-stat-creator/main.go
@@ -150,7 +150,6 @@ func main() {
 				"value", *minScoreFlag,
 				"error", err,
 			)
-			fmt.Printf("Error: invalid min-score value '%s': %v\n", *minScoreFlag, err)
 			return
 		}
 	}
@@ -163,7 +162,6 @@ func main() {
 				"value", *maxScoreFlag,
 				"error", err,
 			)
-			fmt.Printf("Error: invalid max-score value '%s': %v\n", *maxScoreFlag, err)
 			return
 		}
 	}
@@ -173,7 +171,6 @@ func main() {
 			"value", *levelFlag,
 			"error", err,
 		)
-		fmt.Printf("Error: invalid level value '%s': %v\n", *levelFlag, err)
 		return
 	}
 	config := pipeline.Config{
@@ -205,7 +202,6 @@ func main() {
 			"filepath", filepath,
 			"error", err,
 		)
-		fmt.Println("Error calculating statistics:", err)
 		return
 	}
 	logger.Info("Pipeline completed successfully",

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -53,7 +53,6 @@ func (p *Pipeline) Run(ctx context.Context, filename string) (Results,
 
 	in, err := Source(ctx, filename)
 	if err != nil {
-		logger.Error("Pipeline failed at source stage", "error", err)
 		return Results{}, err
 	}
 
@@ -63,7 +62,6 @@ func (p *Pipeline) Run(ctx context.Context, filename string) (Results,
 
 	results, err := Aggregate(ctx, in, p.config)
 	if err != nil {
-		logger.Error("Pipeline failed at aggregation stage", "error", err)
 		return Results{}, err
 	}
 

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -21,10 +21,6 @@ func Source(ctx context.Context, filename string) (<-chan stats.GameScore, error
 	logger.Info("Reading file", "filename", filename)
 	scores, err := reader.ReadScoresFromFile(ctx, filename)
 	if err != nil {
-		logger.Error("File read failed",
-			"filename", filename,
-			"error", err,
-		)
 		return nil, err
 	}
 	logger.Info("File read completed",
@@ -194,10 +190,6 @@ func Aggregate(ctx context.Context, in <-chan stats.GameScore, config Config) (R
 	logger.Info("Calculating overall statistics", "score_count", len(scores))
 	overall, err := stats.CalculateStatistics(scores)
 	if err != nil {
-		logger.Error("Statistics calculation failed",
-			"stage", "overall",
-			"error", err,
-		)
 		return Results{}, err
 	}
 
@@ -206,10 +198,6 @@ func Aggregate(ctx context.Context, in <-chan stats.GameScore, config Config) (R
 		logger.Info("Calculating level statistics", "enabled", true)
 		byLevel, err = stats.CalculateStatisticsByLevel(scores)
 		if err != nil {
-			logger.Error("Statistics calculation failed",
-				"stage", "by_level",
-				"error", err,
-			)
 			return Results{}, err
 		}
 	} else {
@@ -221,10 +209,6 @@ func Aggregate(ctx context.Context, in <-chan stats.GameScore, config Config) (R
 		logger.Info("Calculating player statistics", "enabled", true)
 		byPlayer, err = stats.CalculateStatisticsByPlayer(scores)
 		if err != nil {
-			logger.Error("Statistics calculation failed",
-				"stage", "by_player",
-				"error", err,
-			)
 			return Results{}, err
 		}
 	} else {

--- a/internal/reader/json.go
+++ b/internal/reader/json.go
@@ -30,10 +30,6 @@ func ReadScoresFromFile(ctx context.Context, filename string) ([]stats.GameScore
 	}
 
 	if err := json.Unmarshal(data, &gameScores); err != nil {
-		logger.Error("JSON parsing failed",
-			"filename", filename,
-			"error", err,
-		)
 		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Removed duplicate error logging where errors were both logged AND printed
- Internal packages (reader, pipeline) now only return errors without logging them
- Main application logs errors once using structured logging with `logger.Error()`
- Removed all `fmt.Printf/Println` error printing from main.go

## Problem
The codebase had verbose error handling where errors were logged multiple times:
1. Internal library code logged errors with `logger.Error()` before returning
2. Main application logged the same errors again with `logger.Error()`
3. Main application also printed errors to stdout with `fmt.Printf/Println`

This created triple logging for a single error event.

## Solution
Follows Go best practices:
- **Library/internal code**: Just return errors with context (no logging)
- **Application entry point**: Log errors once with structured logging
- **Single source of truth**: Errors appear exactly once in logs with full context

## Files Changed
- `cmd/cli-stat-creator/main.go` - Removed 4 fmt.Printf/Println error prints
- `internal/reader/json.go` - Removed 1 logger.Error call
- `internal/pipeline/pipeline.go` - Removed 2 logger.Error calls
- `internal/pipeline/stages.go` - Removed 4 logger.Error calls

## Test Plan
- [x] All tests pass: `go test ./...`
- [x] Build succeeds: `go build`
- [x] Verified error logging with invalid flags (min-score, max-score, level)
- [x] Verified error logging with nonexistent files
- [x] Confirmed errors appear once with structured format

🤖 Generated with [Claude Code](https://claude.com/claude-code)