### PR TITLE
Fix MaxScore=0 sentinel value bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The application supports the following command-line flags:
 - `--level <value>`: Filter statistics by level (single: "5" or range: "1-5")
 - `--players <value>`: Filter statistics by player names (comma-separated: "Alice,Bob")
 - `--min-score <value>`: Only include scores >= this value (default: 0)
-- `--max-score <value>`: Only include scores <= this value (default: 0)
+- `--max-score <value>`: Only include scores <= this value (default: no limit)
 
 ### Logging Options
 - `-l`, `--log-level <level>`: Set logging level (debug, info, warn, error; default: warn)

--- a/cmd/cli-stat-creator/main.go
+++ b/cmd/cli-stat-creator/main.go
@@ -84,7 +84,8 @@ func setupLogging(logLevelFlag string) (context.Context, error) {
 // Returns an error if any flag values are invalid.
 func parseFlags(ctx context.Context) (pipeline.Config, error) {
 	logger := logging.FromContext(ctx)
-	var minScore, maxScore int64
+	var minScore int64
+	var maxScore *int
 	var err error
 	if *minScoreFlag == "" {
 		minScore = 0
@@ -99,9 +100,9 @@ func parseFlags(ctx context.Context) (pipeline.Config, error) {
 		}
 	}
 	if *maxScoreFlag == "" {
-		maxScore = 0
+		maxScore = nil
 	} else {
-		maxScore, err = strconv.ParseInt(*maxScoreFlag, 10, 0)
+		maxScoreVal, err := strconv.ParseInt(*maxScoreFlag, 10, 0)
 		if err != nil {
 			logger.Error("Invalid max-score flag value",
 				"value", *maxScoreFlag,
@@ -109,6 +110,8 @@ func parseFlags(ctx context.Context) (pipeline.Config, error) {
 			)
 			return pipeline.Config{}, err
 		}
+		maxScoreInt := int(maxScoreVal)
+		maxScore = &maxScoreInt
 	}
 	levels, err := pipeline.ParseLevelString(*levelFlag)
 	if err != nil {
@@ -142,7 +145,7 @@ func parseFlags(ctx context.Context) (pipeline.Config, error) {
 		CalculateByLevel:  !*noLevelsFlag,
 		CalculateByPlayer: !*noPlayersFlag,
 		MinScore:          int(minScore),
-		MaxScore:          int(maxScore),
+		MaxScore:          maxScore,
 		FilterByLevel:     levels,
 		FilterByPlayer:    players,
 	}, nil

--- a/internal/handlers/stats.go
+++ b/internal/handlers/stats.go
@@ -173,6 +173,17 @@ func parseOptionalInt(value string, defaultValue int) (int, error) {
 	return result, nil
 }
 
+func parseOptionalIntPtr(value string) (*int, error) {
+	if value == "" {
+		return nil, nil
+	}
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func parseQueryParams(r *http.Request) (pipeline.Config, error) {
 	minScoreParam := r.FormValue("min-score")
 	minScore, err := parseOptionalInt(minScoreParam, 0)
@@ -180,7 +191,7 @@ func parseQueryParams(r *http.Request) (pipeline.Config, error) {
 		return pipeline.Config{}, err
 	}
 	maxScoreParam := r.FormValue("max-score")
-	maxScore, err := parseOptionalInt(maxScoreParam, 0)
+	maxScore, err := parseOptionalIntPtr(maxScoreParam)
 	if err != nil {
 		return pipeline.Config{}, err
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,12 +10,13 @@ import (
 
 // Config holds configuration options for filtering game scores in the pipeline.
 type Config struct {
-	FilterByPlayer     []string
-	FilterByLevel      []int
-	MinScore, MaxScore int
-	CalculateByLevel   bool
-	CalculateByPlayer  bool
-	ShowDetailed       bool
+	FilterByPlayer    []string
+	FilterByLevel     []int
+	MinScore          int
+	MaxScore          *int // nil means no maximum limit
+	CalculateByLevel  bool
+	CalculateByPlayer bool
+	ShowDetailed      bool
 }
 
 // Results contains all calculated statistics from a pipeline run.

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -93,9 +93,10 @@ func TestFilter_FilterByLevel(t *testing.T) {
 
 func TestFilter_FilterByScoreRange(t *testing.T) {
 	ctx := context.Background()
+	maxScore := 90
 	config := Config{
 		MinScore: 60,
-		MaxScore: 90,
+		MaxScore: &maxScore,
 	}
 
 	in := make(chan stats.GameScore, 4)
@@ -120,6 +121,71 @@ func TestFilter_FilterByScoreRange(t *testing.T) {
 	for _, score := range results {
 		if score.Score < 60 || score.Score > 90 {
 			t.Errorf("Score %d is outside range [60, 90]", score.Score)
+		}
+	}
+}
+
+func TestFilter_MaxScoreZero(t *testing.T) {
+	ctx := context.Background()
+	maxScore := 0
+	config := Config{
+		MaxScore: &maxScore,
+	}
+
+	in := make(chan stats.GameScore, 3)
+	in <- stats.GameScore{Player: stats.Player{Name: "Alice", ID: 1}, Score: 0, Level: 1}
+	in <- stats.GameScore{Player: stats.Player{Name: "Bob", ID: 2}, Score: 1, Level: 2}
+	in <- stats.GameScore{Player: stats.Player{Name: "Diana", ID: 4}, Score: 10, Level: 2}
+	close(in)
+
+	stage := Filter(config)
+	out := stage(ctx, in)
+
+	var results []stats.GameScore
+	for score := range out {
+		results = append(results, score)
+	}
+
+	// Only scores <= 0 should pass through (Alice=0)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 score, got %d", len(results))
+	}
+	for _, score := range results {
+		if score.Score > 0 {
+			t.Errorf("Score %d is above max 0", score.Score)
+		}
+	}
+}
+
+func TestFilter_NoMaxScore(t *testing.T) {
+	ctx := context.Background()
+	config := Config{
+		MaxScore: nil,
+		MinScore: 50,
+	}
+
+	in := make(chan stats.GameScore, 4)
+	in <- stats.GameScore{Player: stats.Player{Name: "Alice", ID: 1}, Score: 100, Level: 1}
+	in <- stats.GameScore{Player: stats.Player{Name: "Bob", ID: 2}, Score: 50, Level: 2}
+	in <- stats.GameScore{Player: stats.Player{Name: "Charlie", ID: 3}, Score: 1000, Level: 1}
+	in <- stats.GameScore{Player: stats.Player{Name: "Diana", ID: 4}, Score: 25, Level: 2}
+	close(in)
+
+	stage := Filter(config)
+	out := stage(ctx, in)
+
+	var results []stats.GameScore
+	for score := range out {
+		results = append(results, score)
+	}
+
+	// Only scores >= 50 should pass through (no upper limit)
+	if len(results) != 3 {
+		t.Errorf("Expected 3 scores, got %d", len(results))
+	}
+	for _, score := range results {
+		if score.Score < 50 {
+			t.Errorf("Score %d is below min 50", score.Score)
 		}
 	}
 }
@@ -159,10 +225,11 @@ func TestFilter_CombinedPlayerAndLevel(t *testing.T) {
 
 func TestFilter_CombinedPlayerAndScoreRange(t *testing.T) {
 	ctx := context.Background()
+	maxScore := 90
 	config := Config{
 		FilterByPlayer: []string{"Alice", "Bob"},
 		MinScore:       60,
-		MaxScore:       90,
+		MaxScore:       &maxScore,
 	}
 
 	in := make(chan stats.GameScore, 5)
@@ -197,11 +264,12 @@ func TestFilter_CombinedPlayerAndScoreRange(t *testing.T) {
 
 func TestFilter_AllFiltersCombined(t *testing.T) {
 	ctx := context.Background()
+	maxScore := 90
 	config := Config{
 		FilterByPlayer: []string{"Alice"},
 		FilterByLevel:  []int{1, 2},
 		MinScore:       60,
-		MaxScore:       90,
+		MaxScore:       &maxScore,
 	}
 
 	in := make(chan stats.GameScore, 6)

--- a/internal/pipeline/stages.go
+++ b/internal/pipeline/stages.go
@@ -5,6 +5,7 @@ import (
 	"cli-stat-creator/internal/stats"
 	"context"
 	"errors"
+	"fmt"
 )
 
 // Stage represents a processing step in the pipeline that transforms a stream of game scores.
@@ -46,9 +47,13 @@ func Filter(cfg Config) Stage {
 	return func(ctx context.Context, in <-chan stats.GameScore) <-chan stats.GameScore {
 		logger := logging.FromContext(ctx)
 
+		maxScoreLog := "none"
+		if cfg.MaxScore != nil {
+			maxScoreLog = fmt.Sprintf("%d", *cfg.MaxScore)
+		}
 		logger.Info("Filter stage started",
 			"min_score", cfg.MinScore,
-			"max_score", cfg.MaxScore,
+			"max_score", maxScoreLog,
 			"level_filter_count", len(cfg.FilterByLevel),
 			"player_filter_count", len(cfg.FilterByPlayer),
 		)
@@ -114,7 +119,7 @@ func Filter(cfg Config) Stage {
 					continue
 				}
 
-				if cfg.MaxScore > 0 && score.Score > cfg.MaxScore {
+				if cfg.MaxScore != nil && score.Score > *cfg.MaxScore {
 					filteredCount++
 					logger.Debug("Score filtered out",
 						"player", score.Player.Name,


### PR DESCRIPTION
## Summary
Fixed bug where `MaxScore=0` was incorrectly treated as "no maximum limit" instead of filtering for scores <= 0.

Changed `MaxScore` from `int` to `*int` in `pipeline.Config` to properly distinguish between:
- **nil** = no maximum limit (all scores pass through)
- **pointer to 0** = maximum score of 0 (only scores <= 0 pass through)

## Changes
- Updated `Config` struct to use `*int` for `MaxScore` field (internal/pipeline/pipeline.go:16)
- Modified filter logic from `cfg.MaxScore > 0` to `cfg.MaxScore != nil` with pointer dereference (internal/pipeline/stages.go:122)
- Updated CLI flag parsing to return nil or pointer value (cmd/cli-stat-creator/main.go:87-115)
- Updated HTTP query param parsing with new `parseOptionalIntPtr()` helper (internal/handlers/stats.go:176-184)
- Added logging support for nil MaxScore (displays "none" in logs)
- Added test cases: `TestFilter_MaxScoreZero` and `TestFilter_NoMaxScore`
- Updated existing tests to use pointer syntax

## Test Plan
- [x] All unit tests pass (19 tests in pipeline package)
- [x] Manual CLI test: `--max-score 0` correctly filters only scores <= 0
- [x] Manual CLI test: no `--max-score` flag allows all scores through
- [x] Manual CLI test: `--max-score 5` correctly filters scores <= 5
- [x] Manual HTTP test: `max-score=0` parameter correctly filters only scores <= 0
- [x] Manual HTTP test: no `max-score` parameter allows all scores through
- [x] Both CLI and HTTP server build successfully

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)